### PR TITLE
Rework the subprocess not to use fork

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+require: rubocop-rspec
 AllCops:
   Include:
     - 'lib/gem_footprint_analyzer/**/*.rb'
@@ -16,3 +17,6 @@ Layout/SpaceInsideHashLiteralBraces:
 
 Style/SignalException:
   EnforcedStyle: semantic
+
+RSpec/NestedGroups:
+  Max: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.5.1
+  - 2.5.3
   - 2.2
 before_install:
-  - gem install bundler -v 1.16.4
+  - gem install bundler -v 1.17.1
 script:
   - bundle exec rubocop
   - bundle exec rspec
   - bundle exec analyze_requires -d rubocop
-  - bundle exec analyze_requires -g net/http
+  - bundle exec analyze_requires net/http

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in gem_footprint_analyzer.gemspec
 gemspec
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gem_footprint_analyzer (0.1.4)
+    gem_footprint_analyzer (0.1.5)
 
 GEM
   remote: https://rubygems.org/
@@ -53,4 +53,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # GemFootprintAnalyzer
+[![Gem Version](https://badge.fury.io/rb/gem_footprint_analyzer.svg)](https://badge.fury.io/rb/gem_footprint_analyzer)
+[![Build Status](https://travis-ci.com/irvingwashington/gem_footprint_analyzer.svg?branch=master)](https://travis-ci.com/irvingwashington/gem_footprint_analyzer)
 
-A tool for analyzing time and RSS footprint of gems or standard library requires, it's currently in a 'work in progress' state (developed on ruby-2.5.1 / macOS).
+A tool for analyzing time and RSS footprint of gems or standard library requires.
+Requires Ruby >= 2.2.0, works on Linux and MacOS.
 
 ## Installation
 
@@ -20,14 +23,34 @@ Or install it yourself as:
 
 ## Usage
 
-Analyze a standard library require or a gem. In the gem case, make sure it's included in the Gemfile.
+You can use this gem with or without Bundler. Using Bundler is more convenient and does not have any
+impact on results, however you have to have `gem_footprint_analyzer` present in your Gemfile
+(use the development section).
 
-Example usages:
+1) with Bundler
+```bash
+# Standard library
+$ bundle exec analyze_requires net/http
+
+# Gem with non-standard require
+$ bundle exec analyze_requires activerecord active_record
+```
+
+2) without Bundler
+```bash
+# Standard library
+$ analyze_requires net/http
+
+# Analyzing gems without Bundler will require you provide all dependencies paths in the RUBYLIB env var
+$ RUBYLIB=/Users/irving/.gem/ruby/2.5.3/gems/activerecord-5.2.1/lib:/Users/irving/.gem/ruby/2.5.3/gems/activesupport-5.2.1/lib/:/Users/irving/.gem/ruby/2.5.3/gems/concurrent-ruby-1.0.5/lib:/Users/irving/.gem/ruby/2.5.3/gems/i18n-1.1.1/lib:/Users/irving/.gem/ruby/2.5.3/gems/activemodel-5.2.1/lib:/Users/irving/.gem/ruby/2.5.3/gems/arel-9.0.0/lib:/Users/irving/.gem/ruby/2.5.3/gems/tzinfo-1.2.5/lib:/Users/irving/.gem/ruby/2.5.3/gems/thread_safe-0.3.6/lib analyze_requries activerecord active_record
+```
+
+## Example analyses (Ruby 2.5.3):
 
 ### timeout
 ```
-$ bundle exec analyze_requires timeout
-GemFootprintAnalyzer (0.1.1)
+$ analyze_requires timeout
+GemFootprintAnalyzer (0.1.5)
 
 Analyze results (average measured from 10 run(s))
 time is the amount of time given require has taken to complete
@@ -35,43 +58,66 @@ RSS is total memory increase up to the point after the require
 
 name      time   RSS after
 ------------------------
-timeout     3ms   2734KB
+timeout     1ms    226KB
+
+Total runtime 0.3430s
 ```
 
 ### net/http
 ```
-GemFootprintAnalyzer (0.1.1)
+$ analyze_requires net/http
+GemFootprintAnalyzer (0.1.5)
 
 Analyze results (average measured from 10 run(s))
 time is the amount of time given require has taken to complete
 RSS is total memory increase up to the point after the require
 
-name                             time   RSS after
------------------------------------------------
-net/http                         102ms   8605KB
-  net/http/backward                1ms   8605KB
-  net/http/proxy_delta             1ms   8510KB
-  net/http/responses               2ms   8474KB
-  net/http/response                2ms   8160KB
-  net/http/requests                1ms   7984KB
-  net/http/request                 1ms   7801KB
-  net/http/generic_request         2ms   7745KB
-  net/http/header                  2ms   7506KB
-  net/http/exceptions              1ms   7215KB
-  stringio                         0ms   7039KB
-  zlib                             1ms   6920KB
-  uri                              0ms   6713KB
-  net/protocol                    28ms   6610KB
-    io/wait                        0ms   6610KB
-    timeout                        1ms   6397KB
-    socket                        12ms   6168KB
-    io/wait                        1ms   6168KB
-      socket.so                    2ms   5754KB
+name                                 time   RSS after
+---------------------------------------------------
+net/http                             182ms   2897KB
+  net/http/backward                    1ms   2897KB
+  net/http/proxy_delta                 1ms   2886KB
+  net/http/responses                   2ms   2885KB
+  net/http/response                    2ms   2782KB
+  net/http/requests                    1ms   2706KB
+  net/http/request                     1ms   2676KB
+  net/http/generic_request             3ms   2670KB
+  net/http/header                      2ms   2575KB
+  net/http/exceptions                  1ms   2416KB
+  stringio                             1ms   2397KB
+  zlib                                 1ms   2355KB
+  uri                                 78ms   2296KB
+    uri/mailto                         2ms   2296KB
+      uri/generic                      0ms   2296KB
+    uri/ldaps                          1ms   2078KB
+      uri/ldap                         0ms   2078KB
+      uri/ldap                         1ms   2065KB
+      uri/generic                      0ms   2065KB
+    uri/https                          1ms   2016KB
+      uri/http                         0ms   2016KB
+      uri/http                         1ms   2012KB
+      uri/generic                      0ms   2012KB
+    uri/ftp                            1ms   2004KB
+      uri/generic                      0ms   2004KB
+      uri/generic                      4ms   1976KB
+        uri/common                     0ms   1976KB
+        uri/common                    14ms   1698KB
+          uri/rfc3986_parser           2ms   1693KB
+          uri/rfc2396_parser           2ms   1558KB
+  net/protocol                        26ms   1190KB
+    io/wait                            1ms   1190KB
+    timeout                            1ms   1165KB
+    socket                            10ms   1119KB
+    io/wait                            1ms   1119KB
+      socket.so                        1ms   1089KB
+
+Total runtime 2.1813s
 ```
 
 ### activesupport/time
 ```
-GemFootprintAnalyzer (0.1.1)
+$ bundle exec analyze_requires active_support active_support/time
+GemFootprintAnalyzer (0.1.5)
 
 Analyze results (average measured from 10 run(s))
 time is the amount of time given require has taken to complete
@@ -79,242 +125,250 @@ RSS is total memory increase up to the point after the require
 
 name                                                                   time   RSS after
 -------------------------------------------------------------------------------------
-active_support/time                                                   1018ms  13511KB
-  active_support/core_ext/string/zones                                   5ms  13511KB
-    active_support/core_ext/time/zones                                   0ms  13511KB
-    active_support/core_ext/string/conversions                           0ms  13456KB
-    active_support/core_ext/string/conversions                           5ms  13451KB
-      active_support/core_ext/time/calculations                          0ms  13451KB
-      date                                                               0ms  13443KB
-  active_support/core_ext/numeric/time                                   0ms  13416KB
-  active_support/core_ext/integer/time                                  21ms  13413KB
-  active_support/core_ext/numeric/time                                  16ms  13413KB
-    active_support/core_ext/date/acts_like                               0ms  13413KB
-    active_support/core_ext/date/calculations                            0ms  13376KB
-    active_support/core_ext/time/acts_like                               0ms  13371KB
-      active_support/core_ext/time/calculations                          0ms  13364KB
-    active_support/duration                                              0ms  13364KB
-    active_support/duration                                              0ms  13351KB
-  active_support/core_ext/date_time                                     54ms  13339KB
-    active_support/core_ext/date_time/conversions                       17ms  13339KB
-      active_support/values/time_zone                                    0ms  13339KB
-      active_support/core_ext/date_time/calculations                     0ms  13326KB
-      active_support/core_ext/time/conversions                           0ms  13323KB
-      active_support/inflector/methods                                   0ms  13322KB
-      date                                                               0ms  13317KB
-    active_support/core_ext/date_time/compatibility                      5ms  13300KB
-      active_support/core_ext/module/redefine_method                     0ms  13300KB
-      active_support/core_ext/date_and_time/compatibility                0ms  13287KB
-      active_support/core_ext/date_time/calculations                     0ms  13282KB
-    active_support/core_ext/date_time/blank                              1ms  13278KB
-      date                                                               0ms  13278KB
-    active_support/core_ext/date_time/acts_like                          5ms  13264KB
-      active_support/core_ext/object/acts_like                           0ms  13264KB
-      date                                                               0ms  13252KB
-  active_support/core_ext/date                                          42ms  13247KB
-    active_support/core_ext/date/zones                                   0ms  13247KB
-    active_support/core_ext/date/conversions                            13ms  13241KB
-      active_support/core_ext/module/redefine_method                     0ms  13241KB
-    active_support/core_ext/date/zones                                   0ms  13231KB
-      active_support/inflector/methods                                   0ms  13227KB
-      date                                                               0ms  13221KB
-    active_support/core_ext/date/calculations                            0ms  13204KB
-    active_support/core_ext/date/blank                                   1ms  13201KB
-      date                                                               0ms  13201KB
-    active_support/core_ext/date/acts_like                               1ms  13197KB
-      active_support/core_ext/object/acts_like                           0ms  13197KB
-  active_support/core_ext/time                                         817ms  13185KB
-    active_support/core_ext/time/zones                                   0ms  13185KB
-      active_support/core_ext/time/conversions                           0ms  13172KB
-    active_support/core_ext/time/compatibility                           6ms  13170KB
-      active_support/core_ext/module/redefine_method                     1ms  13170KB
-      active_support/core_ext/date_and_time/compatibility                0ms  13147KB
-      active_support/core_ext/time/calculations                        779ms  13142KB
-    active_support/core_ext/date/calculations                           30ms  13142KB
-      active_support/core_ext/date_and_time/calculations                 0ms  13142KB
-    active_support/core_ext/time/zones                                   0ms  13124KB
-    active_support/core_ext/date/zones                                   5ms  13119KB
-      active_support/core_ext/date_and_time/zones                        0ms  13119KB
-      date                                                               0ms  13107KB
-      active_support/core_ext/object/acts_like                           0ms  13094KB
-    active_support/duration                                              0ms  13092KB
-      date                                                               0ms  13088KB
-      active_support/core_ext/date_and_time/calculations                 3ms  13058KB
-        active_support/core_ext/object/try                               1ms  13058KB
-          delegate                                                       0ms  13058KB
-    active_support/core_ext/time/zones                                  10ms  12970KB
-      active_support/core_ext/date_and_time/zones                        1ms  12970KB
-    active_support/core_ext/time/acts_like                               0ms  12900KB
-      active_support/time_with_zone                                      0ms  12890KB
-      active_support/time_with_zone                                     22ms  12858KB
-      active_support/core_ext/date_and_time/compatibility                6ms  12858KB
-        active_support/core_ext/module/attribute_accessors               5ms  12858KB
-          active_support/core_ext/regexp                                 0ms  12858KB
-          active_support/core_ext/array/extract_options                  0ms  12775KB
-      active_support/core_ext/object/acts_like                           0ms  12746KB
-      active_support/values/time_zone                                    0ms  12739KB
-    active_support/duration                                              0ms  12732KB
-      active_support/core_ext/time/conversions                         219ms  12490KB
-      active_support/values/time_zone                                  215ms  12490KB
-        active_support/core_ext/object/blank                             0ms  12490KB
-        concurrent/map                                                   0ms  12439KB
-        tzinfo                                                         200ms  12437KB
-          tzinfo/country_timezone                                        1ms  12437KB
-          tzinfo/country                                                 1ms  12369KB
-            thread_safe                                                  0ms  12369KB
-          tzinfo/zoneinfo_country_info                                   0ms  12275KB
-          tzinfo/ruby_country_info                                       1ms  12266KB
-          tzinfo/country_info                                            1ms  12214KB
-          tzinfo/country_index_definition                                0ms  12196KB
-          tzinfo/timezone_proxy                                          1ms  12156KB
-          tzinfo/linked_timezone                                         1ms  12126KB
-          tzinfo/data_timezone                                           0ms  12083KB
-          tzinfo/info_timezone                                           0ms  12067KB
-          tzinfo/timezone                                               40ms  12017KB
-            thread_safe/cache                                            7ms  12017KB
-              thread_safe/mri_cache_backend                              2ms  12017KB
-                thread_safe/non_concurrent_cache_backend                 1ms  12017KB
-              thread                                                     0ms  11934KB
-            thread_safe                                                 11ms  11846KB
-              thread_safe/synchronized_delegator                         5ms  11846KB
-                monitor                                                  0ms  11846KB
-          delegate                                                       0ms  11791KB
-              thread_safe/version                                        0ms  11782KB
-            set                                                          0ms  11764KB
-      date                                                               0ms  11763KB
-          tzinfo/timezone_period                                         1ms  11679KB
-          tzinfo/zoneinfo_data_source                                    2ms  11641KB
-          tzinfo/ruby_data_source                                        1ms  11597KB
-          tzinfo/data_source                                             1ms  11569KB
-              thread                                                     0ms  11569KB
-          tzinfo/zoneinfo_timezone_info                                  1ms  11553KB
-          tzinfo/transition_data_timezone_info                           1ms  11498KB
-          tzinfo/linked_timezone_info                                    0ms  11456KB
-          tzinfo/data_timezone_info                                      0ms  11440KB
-          tzinfo/timezone_info                                           0ms  11431KB
-          tzinfo/timezone_index_definition                               0ms  11424KB
-          tzinfo/timezone_transition_definition                          1ms  11416KB
-          tzinfo/timezone_transition                                     1ms  11400KB
-          tzinfo/timezone_offset                                         1ms  11388KB
-          tzinfo/timezone_definition                                     0ms  11367KB
-          tzinfo/time_or_datetime                                        5ms  11353KB
-            time                                                         0ms  11353KB
-      date                                                               0ms  11344KB
-          tzinfo/offset_rationals                                        1ms  11306KB
-          tzinfo/ruby_core_support                                       1ms  11263KB
-      date                                                               0ms  11263KB
-      active_support/inflector/methods                                   0ms  11081KB
-    active_support/duration                                            442ms  11070KB
-      active_support/deprecation                                         0ms  11070KB
-      active_support/core_ext/string/filters                             1ms  11042KB
-      active_support/core_ext/object/acts_like                           0ms  11034KB
-      active_support/core_ext/module/delegation                          0ms  11030KB
-      active_support/core_ext/array/conversions                        419ms  11026KB
-        active_support/core_ext/object/to_query                          0ms  11026KB
-        active_support/core_ext/object/to_param                          1ms  11013KB
-        active_support/core_ext/object/to_query                          1ms  11013KB
-          cgi                                                            0ms  11013KB
-        active_support/core_ext/string/inflections                       0ms  10974KB
-        active_support/core_ext/hash/keys                                1ms  10967KB
-        active_support/xml_mini                                        385ms  10915KB
-          active_support/xml_mini/rexml                                 20ms  10915KB
-            stringio                                                     0ms  10915KB
-        active_support/core_ext/object/blank                             5ms  10910KB
-        concurrent/map                                                   0ms  10910KB
-          active_support/core_ext/regexp                                 0ms  10890KB
-            active_support/core_ext/kernel/reporting                     1ms  10861KB
-      active_support/core_ext/date_time/calculations                     1ms  10816KB
-      date                                                               0ms  10816KB
-        active_support/core_ext/string/inflections                     316ms  10741KB
-          active_support/inflector/transliterate                        10ms  10741KB
-            active_support/i18n                                          0ms  10741KB
-            active_support/core_ext/string/multibyte                     1ms  10721KB
-              active_support/multibyte                                   0ms  10721KB
-      active_support/inflector/methods                                 298ms  10675KB
-          active_support/core_ext/regexp                                 0ms  10675KB
-        active_support/inflections                                     283ms  10660KB
-          active_support/inflector/inflections                         281ms  10660KB
-      active_support/deprecation                                        96ms  10660KB
-        active_support/core_ext/module/deprecation                       1ms  10660KB
-        active_support/deprecation/proxy_wrappers                        1ms  10406KB
-          active_support/core_ext/regexp                                 0ms  10406KB
-        active_support/deprecation/method_wrappers                       6ms  10334KB
-          active_support/core_ext/array/extract_options                  1ms  10334KB
-          active_support/core_ext/module/aliasing                        1ms  10312KB
-        active_support/deprecation/constant_accessor                     1ms  10298KB
-        active_support/deprecation/reporting                             1ms  10286KB
-          rbconfig                                                       0ms  10286KB
-        active_support/deprecation/behaviors                            26ms  10247KB
-          active_support/notifications                                  25ms  10247KB
-            active_support/per_thread_registry                           1ms  10247KB
-      active_support/core_ext/module/delegation                          0ms  10247KB
-            active_support/notifications/fanout                          6ms  10200KB
-        concurrent/map                                                   0ms  10200KB
-              mutex_m                                                    1ms  10186KB
-            active_support/notifications/instrumenter                    2ms  10164KB
-              securerandom                                               1ms  10164KB
-        active_support/deprecation/instance_delegator                    5ms  10052KB
-      active_support/core_ext/module/delegation                          0ms  10052KB
-          active_support/core_ext/kernel/singleton_class                 1ms  10033KB
-        singleton                                                        1ms  10026KB
-            active_support/i18n                                         48ms   9995KB
-  i18n/config                                                            1ms   9995KB
-            set                                                          0ms   9995KB
-              active_support/lazy_load_hooks                             1ms   9914KB
-              i18n                                                      20ms   9886KB
-                i18n/interpolate/ruby                                    1ms   9886KB
-                i18n/exceptions                                          1ms   9765KB
-          cgi                                                            0ms   9765KB
-                i18n/version                                             0ms   9620KB
-        concurrent/map                                                   0ms   9598KB
-              active_support/core_ext/hash/slice                         1ms   9491KB
-              active_support/core_ext/hash/except                        0ms   9425KB
-              active_support/core_ext/hash/deep_merge                    1ms   9403KB
-          active_support/core_ext/regexp                                 0ms   9326KB
-            active_support/core_ext/array/prepend_and_append             0ms   9308KB
-        concurrent/map                                                 102ms   9282KB
-          concurrent/collection/map/mri_map_backend                      6ms   9282KB
-            concurrent/collection/map/non_concurrent_map_backend         1ms   9282KB
-              concurrent/constants                                       0ms   9282KB
-              thread                                                     0ms   9021KB
-          concurrent/synchronization                                    79ms   8911KB
-            concurrent/synchronization/lock                              1ms   8911KB
-            concurrent/synchronization/condition                         1ms   8835KB
-            concurrent/synchronization/lockable_object                   1ms   8729KB
-            concurrent/synchronization/truffle_lockable_object           0ms   8659KB
-            concurrent/synchronization/rbx_lockable_object               1ms   8619KB
-            concurrent/synchronization/jruby_lockable_object             0ms   8567KB
-            concurrent/synchronization/mri_lockable_object               1ms   8532KB
-            concurrent/synchronization/abstract_lockable_object          1ms   8468KB
-            concurrent/synchronization/volatile                          0ms   8412KB
-            concurrent/synchronization/object                            1ms   8359KB
-            concurrent/synchronization/truffle_object                    1ms   8238KB
-            concurrent/synchronization/rbx_object                        1ms   8188KB
-            concurrent/synchronization/jruby_object                      1ms   8124KB
-            concurrent/synchronization/mri_object                        1ms   8076KB
-            concurrent/utility/native_extension_loader                   1ms   8000KB
-              concurrent/utility/engine                                  0ms   8000KB
-            concurrent/synchronization/abstract_object                   0ms   7898KB
-              concurrent/utility/engine                                  1ms   7836KB
-              concurrent/constants                                       0ms   7749KB
-              thread                                                     0ms   7675KB
-      active_support/core_ext/module/delegation                          7ms   7019KB
-          active_support/core_ext/regexp                                 0ms   7019KB
-            set                                                          0ms   6888KB
-          bigdecimal                                                     1ms   6718KB
-          base64                                                         1ms   6492KB
-            time                                                         0ms   6321KB
-    active_support/core_ext/time/acts_like                               1ms   5086KB
-      active_support/core_ext/object/acts_like                           0ms   5086KB
-            time                                                         4ms   4698KB
-      date                                                               0ms   4698KB
-      date                                                               4ms   3610KB
-        date_core                                                        2ms   3610KB
+active_support/time                                                   1082ms   5084KB
+  active_support/core_ext/string/zones                                   5ms   5084KB
+    active_support/core_ext/time/zones                                   0ms   5084KB
+    active_support/core_ext/string/conversions                           0ms   5082KB
+    active_support/core_ext/string/conversions                           5ms   5080KB
+      active_support/core_ext/time/calculations                          0ms   5080KB
+      date                                                               0ms   5078KB
+  active_support/core_ext/numeric/time                                   0ms   5074KB
+  active_support/core_ext/integer/time                                  23ms   5074KB
+  active_support/core_ext/numeric/time                                  18ms   5074KB
+    active_support/core_ext/date/acts_like                               0ms   5074KB
+    active_support/core_ext/date/calculations                            0ms   5066KB
+    active_support/core_ext/time/acts_like                               0ms   5066KB
+      active_support/core_ext/time/calculations                          0ms   5066KB
+    active_support/duration                                              0ms   5064KB
+    active_support/duration                                              0ms   5060KB
+  active_support/core_ext/date_time                                     56ms   5058KB
+    active_support/core_ext/date_time/conversions                       18ms   5058KB
+      active_support/values/time_zone                                    0ms   5058KB
+      active_support/core_ext/date_time/calculations                     0ms   5047KB
+      active_support/core_ext/time/conversions                           0ms   5046KB
+      active_support/inflector/methods                                   0ms   5043KB
+      date                                                               0ms   5043KB
+    active_support/core_ext/date_time/compatibility                      5ms   5040KB
+      active_support/core_ext/module/redefine_method                     0ms   5040KB
+      active_support/core_ext/date_and_time/compatibility                0ms   5036KB
+      active_support/core_ext/date_time/calculations                     0ms   5033KB
+    active_support/core_ext/date_time/blank                              1ms   5033KB
+      date                                                               0ms   5033KB
+    active_support/core_ext/date_time/acts_like                          5ms   5028KB
+      active_support/core_ext/object/acts_like                           0ms   5028KB
+      date                                                               0ms   5025KB
+  active_support/core_ext/date                                          43ms   5016KB
+    active_support/core_ext/date/zones                                   0ms   5016KB
+    active_support/core_ext/date/conversions                            13ms   5011KB
+      active_support/core_ext/module/redefine_method                     0ms   5011KB
+    active_support/core_ext/date/zones                                   0ms   5002KB
+      active_support/inflector/methods                                   0ms   5000KB
+      date                                                               0ms   4997KB
+    active_support/core_ext/date/calculations                            0ms   4989KB
+    active_support/core_ext/date/blank                                   1ms   4987KB
+      date                                                               0ms   4987KB
+    active_support/core_ext/date/acts_like                               1ms   4975KB
+      active_support/core_ext/object/acts_like                           0ms   4975KB
+  active_support/core_ext/time                                         878ms   4964KB
+    active_support/core_ext/time/zones                                   0ms   4964KB
+      active_support/core_ext/time/conversions                           0ms   4959KB
+    active_support/core_ext/time/compatibility                           6ms   4958KB
+      active_support/core_ext/module/redefine_method                     1ms   4958KB
+      active_support/core_ext/date_and_time/compatibility                0ms   4939KB
+      active_support/core_ext/time/calculations                        839ms   4931KB
+    active_support/core_ext/date/calculations                           31ms   4931KB
+      active_support/core_ext/date_and_time/calculations                 0ms   4931KB
+    active_support/core_ext/time/zones                                   0ms   4919KB
+    active_support/core_ext/date/zones                                   5ms   4916KB
+      active_support/core_ext/date_and_time/zones                        0ms   4916KB
+      date                                                               0ms   4910KB
+      active_support/core_ext/object/acts_like                           0ms   4904KB
+    active_support/duration                                              0ms   4904KB
+      date                                                               0ms   4904KB
+      active_support/core_ext/date_and_time/calculations                 3ms   4879KB
+        active_support/core_ext/object/try                               1ms   4879KB
+          delegate                                                       0ms   4879KB
+    active_support/core_ext/time/zones                                  10ms   4808KB
+      active_support/core_ext/date_and_time/zones                        1ms   4808KB
+    active_support/core_ext/time/acts_like                               0ms   4798KB
+      active_support/time_with_zone                                      0ms   4796KB
+      active_support/time_with_zone                                     22ms   4788KB
+      active_support/core_ext/date_and_time/compatibility                6ms   4788KB
+        active_support/core_ext/module/attribute_accessors               5ms   4788KB
+          active_support/core_ext/regexp                                 0ms   4788KB
+          active_support/core_ext/array/extract_options                  0ms   4762KB
+      active_support/core_ext/object/acts_like                           0ms   4747KB
+      active_support/values/time_zone                                    0ms   4747KB
+    active_support/duration                                              0ms   4746KB
+      active_support/core_ext/time/conversions                         228ms   4628KB
+      active_support/values/time_zone                                  223ms   4628KB
+        active_support/core_ext/object/blank                             0ms   4628KB
+        concurrent/map                                                   0ms   4599KB
+        tzinfo                                                         208ms   4594KB
+          tzinfo/country_timezone                                        1ms   4594KB
+          tzinfo/country                                                 1ms   4581KB
+            thread_safe                                                  0ms   4581KB
+          tzinfo/zoneinfo_country_info                                   1ms   4566KB
+          tzinfo/ruby_country_info                                       1ms   4561KB
+          tzinfo/country_info                                            1ms   4560KB
+          tzinfo/country_index_definition                                1ms   4554KB
+          tzinfo/timezone_proxy                                          1ms   4552KB
+          tzinfo/linked_timezone                                         1ms   4547KB
+          tzinfo/data_timezone                                           1ms   4540KB
+          tzinfo/info_timezone                                           1ms   4538KB
+          tzinfo/timezone                                               43ms   4532KB
+            thread_safe/cache                                            8ms   4532KB
+              thread_safe/mri_cache_backend                              2ms   4532KB
+                thread_safe/non_concurrent_cache_backend                 1ms   4532KB
+              thread                                                     0ms   4460KB
+            thread_safe                                                 13ms   4418KB
+              thread_safe/synchronized_delegator                         8ms   4418KB
+                monitor                                                  1ms   4418KB
+          delegate                                                       2ms   4384KB
+              thread_safe/version                                        0ms   4353KB
+            set                                                          0ms   4352KB
+      date                                                               0ms   4351KB
+          tzinfo/timezone_period                                         1ms   4292KB
+          tzinfo/zoneinfo_data_source                                    2ms   4269KB
+          tzinfo/ruby_data_source                                        1ms   4208KB
+          tzinfo/data_source                                             1ms   4196KB
+              thread                                                     0ms   4196KB
+          tzinfo/zoneinfo_timezone_info                                  2ms   4175KB
+          tzinfo/transition_data_timezone_info                           1ms   4095KB
+          tzinfo/linked_timezone_info                                    1ms   4052KB
+          tzinfo/data_timezone_info                                      1ms   4037KB
+          tzinfo/timezone_info                                           1ms   4026KB
+          tzinfo/timezone_index_definition                               1ms   4020KB
+          tzinfo/timezone_transition_definition                          1ms   4012KB
+          tzinfo/timezone_transition                                     1ms   4002KB
+          tzinfo/timezone_offset                                         1ms   3991KB
+          tzinfo/timezone_definition                                     1ms   3977KB
+          tzinfo/time_or_datetime                                        5ms   3974KB
+            time                                                         0ms   3974KB
+      date                                                               0ms   3970KB
+          tzinfo/offset_rationals                                        1ms   3953KB
+          tzinfo/ruby_core_support                                       1ms   3940KB
+      date                                                               0ms   3940KB
+      active_support/inflector/methods                                   0ms   3836KB
+    active_support/duration                                            491ms   3833KB
+      active_support/deprecation                                         0ms   3833KB
+      active_support/core_ext/string/filters                             1ms   3779KB
+      active_support/core_ext/object/acts_like                           0ms   3775KB
+      active_support/core_ext/module/delegation                          0ms   3774KB
+      active_support/core_ext/array/conversions                        468ms   3772KB
+        active_support/core_ext/object/to_query                          0ms   3772KB
+        active_support/core_ext/object/to_param                          2ms   3768KB
+        active_support/core_ext/object/to_query                          1ms   3768KB
+          cgi                                                            0ms   3768KB
+        active_support/core_ext/string/inflections                       0ms   3765KB
+        active_support/core_ext/hash/keys                                1ms   3765KB
+        active_support/xml_mini                                        434ms   3756KB
+          active_support/xml_mini/rexml                                 20ms   3756KB
+            stringio                                                     1ms   3756KB
+        active_support/core_ext/object/blank                             5ms   3734KB
+        concurrent/map                                                   0ms   3734KB
+          active_support/core_ext/regexp                                 0ms   3730KB
+            active_support/core_ext/kernel/reporting                     1ms   3718KB
+      active_support/core_ext/date_time/calculations                     2ms   3711KB
+      date                                                               0ms   3711KB
+        active_support/core_ext/string/inflections                     361ms   3669KB
+          active_support/inflector/transliterate                        10ms   3669KB
+            active_support/i18n                                          0ms   3669KB
+            active_support/core_ext/string/multibyte                     1ms   3653KB
+              active_support/multibyte                                   0ms   3653KB
+      active_support/inflector/methods                                 342ms   3638KB
+          active_support/core_ext/regexp                                 0ms   3638KB
+        active_support/inflections                                     326ms   3618KB
+          active_support/inflector/inflections                         324ms   3618KB
+      active_support/deprecation                                       104ms   3618KB
+        active_support/core_ext/module/deprecation                       1ms   3618KB
+        active_support/deprecation/proxy_wrappers                        1ms   3390KB
+          active_support/core_ext/regexp                                 0ms   3390KB
+        active_support/deprecation/method_wrappers                       6ms   3376KB
+          active_support/core_ext/array/extract_options                  1ms   3376KB
+          active_support/core_ext/module/aliasing                        1ms   3374KB
+        active_support/deprecation/constant_accessor                     1ms   3365KB
+        active_support/deprecation/reporting                             4ms   3346KB
+          rbconfig                                                       3ms   3346KB
+        active_support/deprecation/behaviors                            27ms   3106KB
+          active_support/notifications                                  26ms   3106KB
+            active_support/per_thread_registry                           1ms   3106KB
+      active_support/core_ext/module/delegation                          0ms   3106KB
+            active_support/notifications/fanout                          6ms   3056KB
+        concurrent/map                                                   0ms   3056KB
+              mutex_m                                                    1ms   3039KB
+            active_support/notifications/instrumenter                    2ms   2985KB
+              securerandom                                               1ms   2985KB
+        active_support/deprecation/instance_delegator                    6ms   2867KB
+      active_support/core_ext/module/delegation                          0ms   2867KB
+          active_support/core_ext/kernel/singleton_class                 1ms   2840KB
+        singleton                                                        1ms   2828KB
+            active_support/i18n                                         77ms   2786KB
+  i18n/config                                                            1ms   2786KB
+            set                                                          0ms   2786KB
+              active_support/lazy_load_hooks                             1ms   2740KB
+              i18n                                                      48ms   2718KB
+                i18n/interpolate/ruby                                    1ms   2718KB
+                i18n/exceptions                                         25ms   2543KB
+          cgi                                                           24ms   2543KB
+            cgi/util                                                     0ms   2543KB
+            cgi/cookie                                                   4ms   2528KB
+            cgi/util                                                     3ms   2528KB
+              cgi/escape                                                 1ms   2528KB
+            cgi/core                                                     3ms   2452KB
+                i18n/version                                             0ms   2228KB
+        concurrent/map                                                   0ms   2220KB
+              active_support/core_ext/hash/slice                         1ms   2181KB
+              active_support/core_ext/hash/except                        1ms   2164KB
+              active_support/core_ext/hash/deep_merge                    1ms   2154KB
+          active_support/core_ext/regexp                                 0ms   2142KB
+            active_support/core_ext/array/prepend_and_append             1ms   2137KB
+        concurrent/map                                                 107ms   2124KB
+          concurrent/collection/map/mri_map_backend                      6ms   2124KB
+            concurrent/collection/map/non_concurrent_map_backend         1ms   2124KB
+              concurrent/constants                                       0ms   2124KB
+              thread                                                     0ms   2070KB
+          concurrent/synchronization                                    82ms   2055KB
+            concurrent/synchronization/lock                              1ms   2055KB
+            concurrent/synchronization/condition                         1ms   2042KB
+            concurrent/synchronization/lockable_object                   1ms   2021KB
+            concurrent/synchronization/truffle_lockable_object           1ms   1994KB
+            concurrent/synchronization/rbx_lockable_object               1ms   1986KB
+            concurrent/synchronization/jruby_lockable_object             1ms   1966KB
+            concurrent/synchronization/mri_lockable_object               1ms   1949KB
+            concurrent/synchronization/abstract_lockable_object          1ms   1914KB
+            concurrent/synchronization/volatile                          1ms   1891KB
+            concurrent/synchronization/object                            1ms   1866KB
+            concurrent/synchronization/truffle_object                    1ms   1815KB
+            concurrent/synchronization/rbx_object                        1ms   1779KB
+            concurrent/synchronization/jruby_object                      1ms   1742KB
+            concurrent/synchronization/mri_object                        1ms   1707KB
+            concurrent/utility/native_extension_loader                   1ms   1660KB
+              concurrent/utility/engine                                  0ms   1660KB
+            concurrent/synchronization/abstract_object                   1ms   1581KB
+              concurrent/utility/engine                                  1ms   1562KB
+              concurrent/constants                                       0ms   1506KB
+              thread                                                     0ms   1490KB
+      active_support/core_ext/module/delegation                          8ms   1325KB
+          active_support/core_ext/regexp                                 1ms   1325KB
+            set                                                          2ms   1304KB
+          bigdecimal                                                     1ms   1159KB
+          base64                                                         1ms   1108KB
+            time                                                         0ms   1098KB
+    active_support/core_ext/time/acts_like                               1ms    655KB
+      active_support/core_ext/object/acts_like                           0ms    655KB
+            time                                                         3ms    610KB
+      date                                                               0ms    610KB
+      date                                                               2ms    367KB
+        date_core                                                        1ms    367KB
+
+Total runtime 11.2834s
 ```
 
 ### archfiend
 ```
-GemFootprintAnalyzer (0.1.1)
+$ bundle exec analyze_requires archfiend
+GemFootprintAnalyzer (0.1.5)
 
 Analyze results (average measured from 10 run(s))
 time is the amount of time given require has taken to complete
@@ -322,19 +376,23 @@ RSS is total memory increase up to the point after the require
 
 name                                        time   RSS after
 ----------------------------------------------------------
-archfiend                                    62ms   6658KB
-  archfiend/subprocess_loop                   1ms   6658KB
-  archfiend/thread_loop                       1ms   6345KB
-  archfiend/shared_loop/runnable              1ms   6150KB
-  archfiend/logging/multi_logger              1ms   6012KB
-  archfiend/logging/default_formatter         1ms   5816KB
-  archfiend/logging/base_formatter            1ms   5640KB
-  archfiend/logging                           5ms   5420KB
-    logger                                    4ms   5420KB
-      monitor                                 0ms   5420KB
-  archfiend/application                       3ms   3942KB
-  archfiend/version                           1ms   2395KB
-  forwardable                                 0ms   1858KB
+archfiend                                    64ms    888KB
+  archfiend/daemon                            1ms    888KB
+  archfiend/subprocess_loop                   1ms    855KB
+  archfiend/thread_loop                       1ms    835KB
+  archfiend/shared_loop/runnable              0ms    820KB
+  archfiend/logging/multi_logger              1ms    817KB
+  archfiend/logging/default_formatter         0ms    804KB
+  archfiend/logging/base_formatter            1ms    800KB
+  archfiend/logging                           5ms    779KB
+    logger                                    4ms    779KB
+      monitor                                 1ms    779KB
+  archfiend/application                       1ms    490KB
+  archfiend/version                           0ms    327KB
+  forwardable                                 2ms    309KB
+    forwardable/impl                          1ms    309KB
+
+Total runtime 0.9878s
 ```
 
 ## Contributing

--- a/lib/gem_footprint_analyzer.rb
+++ b/lib/gem_footprint_analyzer.rb
@@ -1,11 +1,15 @@
 require 'gem_footprint_analyzer/version'
 require 'gem_footprint_analyzer/transport'
-require 'gem_footprint_analyzer/require_spy'
+require 'gem_footprint_analyzer/child_process'
 require 'gem_footprint_analyzer/analyzer'
 require 'gem_footprint_analyzer/average_runner'
 require 'gem_footprint_analyzer/cli'
 require 'gem_footprint_analyzer/core_ext/array'
 require 'gem_footprint_analyzer/core_ext/hash'
+require 'gem_footprint_analyzer/core_ext/file'
+require 'gem_footprint_analyzer/formatters/text_base'
+require 'gem_footprint_analyzer/formatters/tree'
+require 'gem_footprint_analyzer/formatters/json'
 
 module GemFootprintAnalyzer
 end

--- a/lib/gem_footprint_analyzer/child_context.rb
+++ b/lib/gem_footprint_analyzer/child_context.rb
@@ -1,0 +1,58 @@
+require_relative 'require_spy'
+require_relative 'transport'
+
+module GemFootprintAnalyzer
+  # A class that is loaded by the child process to faciliate require tracing.
+  # When `start_child_context` env is passed, it is instantiated and start is called automatically
+  # on require.
+  class ChildContext
+    PARENT_FIFO = '/tmp/parent'.freeze
+    CHILD_FIFO = '/tmp/child'.freeze
+
+    def initialize
+      output Process.pid
+      init_transport
+    end
+
+    # Installs the require-spying code and starts requiring
+    def start
+      RequireSpy.spy_require(transport)
+      begin
+        require(require_string)
+      rescue LoadError => e
+        transport.exit_with_error(e)
+      end
+      transport.done_and_wait_for_ack
+    end
+
+    private
+
+    attr_reader :transport
+
+    def child_fifo
+      ENV['child_fifo']
+    end
+
+    def parent_fifo
+      ENV['parent_fifo']
+    end
+
+    def require_string
+      ENV['require_string']
+    end
+
+    def init_transport
+      write_stream = File.open(child_fifo, 'w')
+      read_stream = File.open(parent_fifo, 'r')
+
+      @transport = Transport.new(read_stream: read_stream, write_stream: write_stream)
+    end
+
+    def output(message)
+      STDOUT.puts(message)
+      STDOUT.flush
+    end
+  end
+end
+
+GemFootprintAnalyzer::ChildContext.new.start if ENV['start_child_context']

--- a/lib/gem_footprint_analyzer/child_process.rb
+++ b/lib/gem_footprint_analyzer/child_process.rb
@@ -1,0 +1,55 @@
+require 'open3'
+require 'rbconfig'
+
+module GemFootprintAnalyzer
+  # A class for starting the child process that does actual requires.
+  class ChildProcess
+    RUBY_CMD = [RbConfig.ruby, '--disable=did_you_mean', '--disable=gem'].freeze
+
+    def initialize(library, require_string, fifos)
+      @library = library
+      @require_string = require_string || library
+      @fifos = fifos
+      @pid = nil
+    end
+
+    def start_child
+      @child_thread ||= Thread.new do # rubocop:disable Naming/MemoizedInstanceVariableName
+        Open3.popen3(child_env_vars, *RUBY_CMD, context_file) do |_, stdout, stderr|
+          @pid = stdout.gets.strip.to_i
+
+          while (line = stderr.gets)
+            puts "!! #{line.strip}"
+          end
+        end
+      end
+    end
+
+    def pid
+      return unless child_thread
+
+      sleep 0.01 while @pid.nil?
+
+      @pid
+    end
+
+    private
+
+    attr_reader :require_string, :child_thread, :fifos
+
+    def child_env_vars
+      {
+        'require_string' => require_string,
+        'start_child_context' => 'true',
+        'child_fifo' => fifos[:child],
+        'parent_fifo' => fifos[:parent],
+        'RUBYOPT' => '', # Stop bundler from requiring bundler/setup
+        'RUBYLIB' => $LOAD_PATH.join(':') # Include bundler-provided paths and paths passed by user
+      }
+    end
+
+    def context_file
+      File.join(__dir__, 'child_context.rb')
+    end
+  end
+end

--- a/lib/gem_footprint_analyzer/core_ext/file.rb
+++ b/lib/gem_footprint_analyzer/core_ext/file.rb
@@ -1,0 +1,11 @@
+module GemFootprintAnalyzer
+  module CoreExt
+    # Provides File#mkfifo, missing in Ruby 2.2.0
+    module File
+      def mkfifo(name)
+        system("mkfifo #{name}")
+      end
+    end
+  end
+end
+File.extend(GemFootprintAnalyzer::CoreExt::File) unless File.respond_to?(:mkfifo)

--- a/lib/gem_footprint_analyzer/version.rb
+++ b/lib/gem_footprint_analyzer/version.rb
@@ -1,3 +1,3 @@
 module GemFootprintAnalyzer
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end


### PR DESCRIPTION
Fork approach is simple, but comes with several downsides.
The biggest one is that all requires are passed along to the
sub process, meaning things like 'optparse' can't be analyzed.
The new version spawns another Ruby process, that doesn't load
anything except for the inspected require.
Transport is switched to FIFO pipes.