### PR TITLE
Get rid of Ruby 2.2.0 warnings

### DIFF
--- a/exe/analyze_requires
+++ b/exe/analyze_requires
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby --disable=did_you_mean --disable=gem --disable=rubyopt
+#!/usr/bin/env ruby --disable=gem --disable=rubyopt
 
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 $LOAD_PATH.unshift('./lib') if Dir.exist?('lib')

--- a/spec/gem_footprint_analyzer/child_process_spec.rb
+++ b/spec/gem_footprint_analyzer/child_process_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GemFootprintAnalyzer::ChildProcess do
 
     before do
       allow(instance).to receive(:context_file).and_return('child_context.rb')
-      stub_const('GemFootprintAnalyzer::ChildProcess::RUBY_CMD', ['ruby', '--param'])
+      allow(instance).to receive(:ruby_command).and_return(['ruby', '--param'])
     end
 
     it 'runs new Ruby process in another thread' do # rubocop:disable RSpec/ExampleLength


### PR DESCRIPTION
By removing `disable=did_you_mean` from params when Ruby < 2.3.0.